### PR TITLE
Add missing fuse.subtype check

### DIFF
--- a/README.fuse
+++ b/README.fuse
@@ -9,7 +9,7 @@ ninja
 cat << EOF | sudo tee /sbin/mount.fuse.passthrough_ll
 #!/bin/bash
 ulimit -n 1048576
-exec $(pwd)/example/passthrough_ll -ofsname="\$@"
+exec $(pwd)/example/passthrough_ll -ofsname="\$@" -o subtype=passthrough_ll
 EOF
 sudo chmod +x /sbin/mount.fuse.passthrough_ll
 mkdir -p /mnt/test /mnt/scratch /home/test/test /home/test/scratch

--- a/check
+++ b/check
@@ -281,7 +281,7 @@ while [ $# -gt 0 ]; do
 	case "$1" in
 	-\? | -h | --help) usage ;;
 
-	-nfs|-afs|-glusterfs|-cifs|-9p|-fuse|-virtiofs|-pvfs2|-tmpfs|-ubifs)
+	-nfs|-afs|-glusterfs|-cifs|-9p|-fuse|-redfs|-virtiofs|-pvfs2|-tmpfs|-ubifs)
 		FSTYP="${1:1}"
 		;;
 	-overlay)

--- a/common/config
+++ b/common/config
@@ -347,6 +347,9 @@ _common_mount_opts()
 	fuse)
 		echo $FUSE_MOUNT_OPTIONS
 		;;
+	redfs)
+		echo $FUSE_MOUNT_OPTIONS
+		;;
 	xfs)
 		echo $XFS_MOUNT_OPTIONS
 		;;
@@ -527,6 +530,8 @@ _source_specific_fs()
 		;;
 	fuse)
 		;;
+	redfs)
+		;;
 	ceph)
 		. ./common/ceph
 		;;
@@ -599,7 +604,7 @@ _check_device()
 	fi
 
 	case "$FSTYP" in
-	9p|fuse|tmpfs|virtiofs|afs)
+	9p|fuse|redfs|tmpfs|virtiofs|afs)
 		# 9p, fuse, virtiofs and afs mount tags are just plain strings,
 		# so anything is allowed tmpfs doesn't use mount source, ignore
 		;;

--- a/common/rc
+++ b/common/rc
@@ -581,6 +581,8 @@ _test_mkfs()
     fuse)
 	# do nothing for fuse
 	;;
+    redfs)
+	;;
     virtiofs)
 	# do nothing for virtiofs
 	;;
@@ -625,6 +627,8 @@ _try_mkfs_dev()
 	;;
     fuse)
 	# do nothing for fuse
+	;;
+    redfs)
 	;;
     virtiofs)
 	# do nothing for virtiofs
@@ -694,7 +698,7 @@ _scratch_mkfs()
 	local mkfs_status
 
 	case $FSTYP in
-	nfs*|afs|cifs|ceph|overlay|glusterfs|pvfs2|9p|fuse|virtiofs)
+	nfs*|afs|cifs|ceph|overlay|glusterfs|pvfs2|9p|fuse|redfs|virtiofs)
 		# unable to re-create this fstyp, just remove all files in
 		# $SCRATCH_MNT to avoid EEXIST caused by the leftover files
 		# created in previous runs
@@ -1640,7 +1644,7 @@ _require_scratch_nocheck()
 			_notrun "this test requires a valid \$SCRATCH_MNT"
 		fi
 		;;
-	9p|fuse|virtiofs)
+	9p|fuse|virtiofs|redfs)
 		if [ -z "$SCRATCH_DEV" ]; then
 			_notrun "this test requires a valid \$SCRATCH_DEV"
 		fi
@@ -1851,7 +1855,7 @@ _require_test()
 			_notrun "this test requires a valid \$TEST_DIR"
 		fi
 		;;
-	9p|fuse|virtiofs)
+	9p|fuse|virtiofs|redfs)
 		if [ -z "$TEST_DEV" ]; then
 			_notrun "this test requires a valid \$TEST_DEV"
 		fi
@@ -3244,6 +3248,8 @@ _check_test_fs()
     fuse)
 	# no way to check consistency for fuse
 	;;
+    redfs)
+	;;
     virtiofs)
 	# no way to check consistency for virtiofs
 	;;
@@ -3310,6 +3316,8 @@ _check_scratch_fs()
 	;;
     fuse)
 	# no way to check consistency for fuse
+	;;
+    redfs)
 	;;
     virtiofs)
 	# no way to check consistency for virtiofs

--- a/common/rc
+++ b/common/rc
@@ -4538,7 +4538,7 @@ init_rc()
 
 	# Sanity check that TEST partition is not mounted at another mount point
 	# or as another fs type
-	_check_mounted_on TEST_DEV $TEST_DEV TEST_DIR $TEST_DIR $FSTYP || exit 1
+	_check_mounted_on TEST_DEV $TEST_DEV TEST_DIR $TEST_DIR $FSTYP$FUSE_SUBTYP || exit 1
 	if [ -n "$SCRATCH_DEV" ]; then
 		# Sanity check that SCRATCH partition is not mounted at another
 		# mount point, because it is about to be unmounted and formatted.


### PR DESCRIPTION
It is observed by running the xfstest suite that we mount fuse along with correct subtype but during mount check we do not check against FUSE_SUBTYP option. Script used by mount for fuse subtype passthrough_ll i.e '/sbin/mount.fuse.passthrough_ll' or any other Fuse subtype script should also mention '-o subtype' option to make it work correctly.